### PR TITLE
Add elections.proxy and set elections as an application behind a reverse proxy

### DIFF
--- a/fedora_elections/__init__.py
+++ b/fedora_elections/__init__.py
@@ -38,7 +38,8 @@ from fedora.client import AuthError, AppError
 from fedora.client.fas2 import AccountSystem
 from flask.ext.fas_openid import FAS
 
-import fedmsgshim
+import fedora_elections.fedmsgshim
+import fedora_elections.proxy
 
 APP = flask.Flask(__name__)
 APP.config.from_object('fedora_elections.default_config')
@@ -47,6 +48,7 @@ if 'FEDORA_ELECTIONS_CONFIG' in os.environ:  # pragma: no cover
 
 # set up FAS
 FAS = FAS(APP)
+APP.wsgi_app = fedora_elections.proxy.ReverseProxied(APP.wsgi_app)
 
 # FAS for usernames.
 FAS2 = AccountSystem(

--- a/fedora_elections/proxy.py
+++ b/fedora_elections/proxy.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2, or (at your option) any later
+# version.  This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.  You
+# should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# Any Red Hat trademarks that are incorporated in the source
+# code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission
+# of Red Hat, Inc.
+#
+
+'''
+Makes elections an application behind a reverse proxy and thus ensure the
+redirects are using ``https``.
+
+Source: http://flask.pocoo.org/snippets/35/ by Peter Hansen
+'''
+
+
+class ReverseProxied(object):
+    '''Wrap the application in this middleware and configure the
+    front-end server to add these headers, to let you quietly bind
+    this to a URL other than / and to an HTTP scheme that is
+    different than what is used locally.
+
+    In nginx:
+    location /myprefix {
+        proxy_pass http://192.168.0.1:5001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Scheme $scheme;
+        proxy_set_header X-Script-Name /myprefix;
+        }
+
+    :param app: the WSGI application
+    '''
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        script_name = environ.get('HTTP_X_SCRIPT_NAME', '')
+        if script_name:
+            environ['SCRIPT_NAME'] = script_name
+            path_info = environ['PATH_INFO']
+            if path_info.startswith(script_name):
+                environ['PATH_INFO'] = path_info[len(script_name):]
+
+        scheme = environ.get('HTTP_X_SCHEME', '')
+        if scheme:
+            environ['wsgi.url_scheme'] = scheme
+        return self.app(environ, start_response)


### PR DESCRIPTION
This will ensure that flask.redirect is using `https` where asked.

Fixes https://fedorahosted.org/fedora-infrastructure/ticket/4369 for elections
