### PR TITLE
Use dogpile.cache to vastly speed up the app.

### DIFF
--- a/fedora_elections/__init__.py
+++ b/fedora_elections/__init__.py
@@ -38,6 +38,8 @@ from fedora.client import AuthError, AppError
 from fedora.client.fas2 import AccountSystem
 from flask.ext.fas_openid import FAS
 
+import dogpile.cache
+
 import fedora_elections.fedmsgshim
 import fedora_elections.proxy
 
@@ -63,6 +65,9 @@ FAS2 = AccountSystem(
 from fedora_elections import models
 SESSION = models.create_session(APP.config['DB_URL'])
 from fedora_elections import forms
+
+cache = dogpile.cache.make_region()
+cache.configure(**APP.config['DOGPILE_CACHE'])
 
 
 def is_authenticated():

--- a/fedora_elections/default_config.py
+++ b/fedora_elections/default_config.py
@@ -22,3 +22,10 @@ FAS_BASE_URL = 'https://admin.stg.fedoraproject.org/accounts/'
 FAS_USERNAME = ''
 FAS_PASSWORD = ''
 FAS_CHECK_CERT = False
+
+DOGPILE_CACHE = {
+    'backend': 'dogpile.cache.dbm',
+    'arguments': {
+        'filename': '/var/tmp/elections-cache.dbm',
+    },
+}

--- a/fedora_elections/elections.py
+++ b/fedora_elections/elections.py
@@ -37,6 +37,7 @@ from fedora_elections import (
     APP, SESSION, FAS2, is_authenticated, is_admin, is_election_admin,
     is_safe_url, safe_redirect_back,
 )
+from fedora_elections.utils import build_name_map
 
 
 def login_required(f):
@@ -166,16 +167,7 @@ def vote_range(election):
             flask.flash("Please confirm your vote!")
             next_action = 'vote'
 
-    usernamemap = {}
-    if (election.candidates_are_fasusers):  # pragma: no cover
-        for candidate in election.candidates:
-            try:
-                usernamemap[str(candidate.id)] = \
-                    FAS2.person_by_username(candidate.name)['human_name']
-            except (KeyError, AuthError), err:
-                APP.logger.debug(err)
-                # User has their name set to private or user doesn't exist.
-                usernamemap[str(candidate.id)] = candidate.name
+    usernamemap = build_name_map(election)
 
     return flask.render_template(
         'vote_range.html',
@@ -239,16 +231,7 @@ def vote_select(election):
                 flask.flash("Please confirm your vote!")
                 next_action = 'vote'
 
-    usernamemap = {}
-    if (election.candidates_are_fasusers):  # pragma: no cover
-        for candidate in election.candidates:
-            try:
-                usernamemap[candidate.name] = \
-                    FAS2.person_by_username(candidate.name)['human_name']
-            except (KeyError, AuthError), err:
-                APP.logger.debug(err)
-                # User has their name set to private or user doesn't exist.
-                usernamemap[candidate.name] = candidate.name
+    usernamemap = build_name_map(election)
 
     return flask.render_template(
         'vote_simple.html',
@@ -376,15 +359,7 @@ def election_results(election_alias):
                 'election_results_text', election_alias=election.alias)
             )
 
-    usernamemap = {}
-    if (election.candidates_are_fasusers):  # pragma: no cover
-        for candidate in election.candidates:
-            try:
-                usernamemap[candidate.id] = \
-                    FAS2.person_by_username(candidate.name)['human_name']
-            except (KeyError, AuthError):
-                # User has their name set to private or user doesn't exist.
-                usernamemap[candidate.id] = candidate.name
+    usernamemap = build_name_map(election)
 
     stats = models.Vote.get_election_stats(SESSION, election.id)
 
@@ -408,15 +383,7 @@ def election_results_text(election_alias):
             "The text results are only available to the admins", "error")
         return safe_redirect_back()
 
-    usernamemap = {}
-    if (election.candidates_are_fasusers):  # pragma: no cover
-        for candidate in election.candidates:
-            try:
-                usernamemap[candidate.id] = \
-                    FAS2.person_by_username(candidate.name)['human_name']
-            except (KeyError, AuthError):
-                # User has their name set to private or user doesn't exist.
-                usernamemap[candidate.id] = candidate.name
+    usernamemap = build_name_map(election)
 
     stats = models.Vote.get_election_stats(SESSION, election.id)
 

--- a/fedora_elections/utils.py
+++ b/fedora_elections/utils.py
@@ -1,0 +1,28 @@
+import fedora_elections
+
+from fedora.client import AuthError
+
+
+def build_name_map(election):
+    """ Returns a mapping of candidate ids to fas human_names. """
+    if not election.candidates_are_fasusers:
+        return {}
+
+    return dict([
+        (str(candidate.id), get_fas_human_name(candidate.name))
+        for candidate in election.candidates
+    ])
+
+
+@fedora_elections.cache.cache_on_arguments()
+def get_fas_human_name(username):
+    """ Given a fas username, return the fas human_name if possible.
+
+    If the user has their name set to private or they don't exist, we just
+    return the given username as a stand-in.
+    """
+    try:
+        return fedora_elections.FAS2.person_by_username(username)['human_name']
+    except (KeyError, AuthError), err:
+        fedora_elections.APP.logger.debug(err)
+        return username

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ python-openid-cla
 python-openid-teams
 SQLAlchemy
 wtforms
+dogpile.cache


### PR DESCRIPTION
Currently, every page load in the voting process requires that the
elections make `N` queries to FAS where `N` is the number of
candidates.  It's being really slow in production tonight with the
opening of the Council election.

This should add some generic caching so that we can use an on-disk .dbm
cache if we like or alternatively memcached.

Tested locally.
