### PR TITLE
Candidate modification revote bug

### DIFF
--- a/fedora_elections/elections.py
+++ b/fedora_elections/elections.py
@@ -374,7 +374,7 @@ def election_results_text(election_alias):
 def process_vote(candidates, election, votes, revote, cand_name=None, value=None):
     for index in range(len(candidates)):
         candidate = candidates[index]
-        if revote:
+        if revote and (index+1 == len(votes)):
             vote = votes[index]
             if value is not None:
                 vote.candidate_id = candidate.data

--- a/fedora_elections/elections.py
+++ b/fedora_elections/elections.py
@@ -374,7 +374,7 @@ def election_results_text(election_alias):
 def process_vote(candidates, election, votes, revote, cand_name=None, value=None):
     for index in range(len(candidates)):
         candidate = candidates[index]
-        if revote and (index+1 == len(votes)):
+        if revote and (index+1 <= len(votes)):
             vote = votes[index]
             if value is not None:
                 vote.candidate_id = candidate.data

--- a/tests/test_flask_range_voting.py
+++ b/tests/test_flask_range_voting.py
@@ -312,7 +312,7 @@ class FlaskRangeElectionstests(ModelFlasktests):
             self.assertEqual(votes[1].value, 0)
             self.assertEqual(votes[2].value, 2)
         #Let's not do repetition of what is tested above we aren't testing the
-        #functionality of voting as that has already been asserted                 
+        #functionality of voting as that has already been asserted
 
             obj = fedora_elections.models.Candidate(  # id:16
                 election_id=3,

--- a/tests/test_flask_range_voting.py
+++ b/tests/test_flask_range_voting.py
@@ -312,13 +312,23 @@ class FlaskRangeElectionstests(ModelFlasktests):
             self.assertEqual(votes[1].value, 0)
             self.assertEqual(votes[2].value, 2)
         #Let's not do repetition of what is tested above we aren't testing the
-        #functionality of voting as that has already been asserted
+        #functionality of voting as that has already been asserted                 
+
+            obj = fedora_elections.models.Candidate(  # id:16
+                election_id=3,
+                name='Josh',
+                url='https://fedoraproject.org/wiki/User:Nerdsville',
+            )
+            self.session.add(obj)
+            self.session.commit()
+
 
         #Next, we need to try revoting
             newdata = {
                 '4': 2,
                 '5': 1,
                 '6': 1,
+                '16': 0,
                 'action': 'submit',
                 'csrf_token': csrf_token,
             }
@@ -336,6 +346,7 @@ class FlaskRangeElectionstests(ModelFlasktests):
             self.assertEqual(votes[0].value, 2)
             self.assertEqual(votes[1].value, 1)
             self.assertEqual(votes[2].value, 1)
+            self.assertEqual(votes[3].value, 0)
         #If we haven't failed yet, HOORAY!
 
 


### PR DESCRIPTION
When candidates were modified between vote and revote, the index of the list went out of range, because it is technically not a revote for that specific candidate. This fix checks if the candidate is in range and if it isn't, it creates a new vote for the candidate.