### PR TITLE
Add a vagrantfile to hack on elections using Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 dist/
 .coverage
 alembic.ini
+.vagrant/

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,39 @@ adapted to other projects.  Fedora-elections is integrated with the Fedora
 Account System (FAS).
 
 
+Hacking with Vagrant
+====================
+Quickly start hacking on elections using the vagrant setup that is included in
+the elections repo is super simple.
+
+First, install Vagrant and the vagrant-libvirt plugin from the official Fedora
+repos::
+
+    $ sudo dnf install vagrant vagrant-libvirt
+
+The elections vagrant setup uses vagrant-sshfs for syncing files between your
+host and the vagrant dev machine. vagrant-sshfs is not in the Fedora repos
+(yet), so we install the vagrant-sshfs plugin from dustymabe's COPR repo::
+
+    $ sudo dnf copr enable dustymabe/vagrant-sshfs
+    $ sudo dnf install vagrant-sshfs
+
+Now, from within main directory (the one with the Vagrantfile in it) of your git
+checkout of elections, run the ``vagrant up`` command to provision your dev
+environment::
+
+    $ vagrant up
+
+When this command is completed (it may take a while) you will be able to ssh
+into your dev VM with ``vagrant ssh`` and then run the command to start the
+elections server::
+
+    $ vagrant ssh
+    [vagrant@localhost ~]$ pushd /vagrant/; ./runserver.py --host "0.0.0.0";
+
+Once that is running, simply go to http://localhost:5002/ in your browser on
+your host to see your running elections test instance.
+
 Running from a checkout:
 ========================
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,12 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/23/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-23-20151030.x86_64.vagrant-libvirt.box"
+  config.vm.box = "f23-cloud-libvirt"
+  config.vm.network "forwarded_port", guest: 5000, host: 5002
+  config.vm.synced_folder ".", "/vagrant", type: "sshfs"
+  config.vm.provision "shell", inline: "dnf -y install python redhat-rpm-config python-devel python-pip rpl"
+  config.vm.provision "shell", inline: "pushd /vagrant/; pip install -r requirements.txt"
+  config.vm.provision "shell", inline: "pushd /vagrant/; python createdb.py", privileged: false
+end

--- a/runserver.py
+++ b/runserver.py
@@ -25,6 +25,10 @@ parser.add_argument(
 parser.add_argument(
     '--port', '-p', default=5000,
     help='Port for the flask application.')
+parser.add_argument(
+    '--host', default="127.0.0.1",
+    help='Hostname to listen on. When set to 0.0.0.0 the server is available \
+    externally. Defaults to 127.0.0.1 making the it only visable on localhost')
 
 args = parser.parse_args()
 
@@ -43,4 +47,4 @@ if args.config:
     os.environ['FEDORA_ELECTIONS_CONFIG'] = config
 
 APP.debug = True
-APP.run(host='127.0.0.1', port=int(args.port))
+APP.run(host=args.host, port=int(args.port))


### PR DESCRIPTION
This adds a Vagrantfile to easily hack on Fedora Elections using vagrant.

I also added the ability to set the host in runserver.py.