### PR TITLE
Specify rel="noopener noreferrer" to link including target='_blank'

### DIFF
--- a/fedora_elections/templates/base.html
+++ b/fedora_elections/templates/base.html
@@ -81,7 +81,7 @@
 
         <p id="footer">
           Copyright &copy; 2013-2014 Red Hat
-          <a href="//github.com/fedora-infra/elections/"
+          <a href="//github.com/fedora-infra/elections/" rel="noopener noreferrer"
           target="_blank">elections</a>
         -- version: {{ version }}
         </p>


### PR DESCRIPTION
This avoids potential security risk:
https://dev.to/ben/the-targetblank-vulnerability-by-example
https://mathiasbynens.github.io/rel-noopener/