### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/fedora_elections/admin.py
+++ b/fedora_elections/admin.py
@@ -409,7 +409,7 @@ def admin_delete_candidate(election_alias, candidate_id):
                     candidate=candidate.to_json(),
                 )
             )
-        except SQLAlchemyError, err:
+        except SQLAlchemyError as err:
             SESSION.rollback()
             APP.logger.debug('Could not delete candidate')
             APP.logger.exception(err)

--- a/fedora_elections/fedmsgshim.py
+++ b/fedora_elections/fedmsgshim.py
@@ -13,5 +13,5 @@ def publish(*args, **kwargs):  # pragma: no cover
     try:
         import fedmsg
         fedmsg.publish(*args, **kwargs)
-    except Exception, e:
+    except Exception as e:
         warnings.warn(str(e))

--- a/fedora_elections/forms.py
+++ b/fedora_elections/forms.py
@@ -150,7 +150,7 @@ def get_simple_voting_form(candidates, fasusers):
             try:
                 title = \
                     FAS2.person_by_username(candidate.name)['human_name']
-            except (KeyError, AuthError), err:
+            except (KeyError, AuthError) as err:
                 APP.logger.debug(err)
         if candidate.url:
             title = '%s <a href="%s">[Info]</a>' % (title, candidate.url)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -20,6 +20,7 @@
 
  fedora_elections test script
 """
+from __future__ import print_function
 
 __requires__ = ['SQLAlchemy >= 0.7']
 import pkg_resources
@@ -57,7 +58,7 @@ if os.environ.get('BUILD_ID'):
         req = requests.get('%s/new' % FAITOUT_URL)
         if req.status_code == 200:
             DB_PATH = req.text
-            print 'Using faitout at: %s' % DB_PATH
+            print('Using faitout at: %s' % DB_PATH)
     except:
         pass
 


### PR DESCRIPTION
* Old style exceptions --> new style in Python 3
    * Python 3 treats old style exceptions as syntax errors but new style exceptions work as expected in both Python 2 and Python 3.
* Use __print()__ function in both Python 2 and Python 3
    * __print()__ is a function in Python 3.